### PR TITLE
Fix xrange for Python 3

### DIFF
--- a/ed25519.py
+++ b/ed25519.py
@@ -13,6 +13,7 @@ if PY3:
     indexbytes = operator.getitem
     intlist2bytes = bytes
     int2byte = operator.methodcaller("to_bytes", 1, "big")
+    xrange = range
 else:
     int2byte = chr
 


### PR DESCRIPTION
scalarmult_B is hot enough that it's probably best to stick with
xrange when in Python 2, so let's make 'xrange' work in Python 3.
