### PR TITLE
Fix invalid escape sequence in docstring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,23 @@
 language: python
-python: 2.7
-env:
-    - TOXENV=py26
-    - TOXENV=py27
-    - TOXENV=py32
-    - TOXENV=py33
-    - TOXENV=pypy
-    - TOXENV=pep8
+cache: pip
+jobs:
+  include:
+    - python: "2.7"
+      env: TOXENV=py27
+    - python: "3.5"
+      env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=py36
+    - python: "3.7"
+      env: TOXENV=py37
+    - python: "3.8"
+      env: TOXENV=py38
+    - python: "3.9"
+      env: TOXENV=py39
+    - python: "pypy"
+      env: TOXENV=pypy
+    - python: "3.9"
+      env: TOXENV=pep8
 
 install:
     # Add the PyPy repository

--- a/ed25519.py
+++ b/ed25519.py
@@ -47,7 +47,7 @@ if PY3:
     int2byte = operator.methodcaller("to_bytes", 1, "big")
 else:
     int2byte = chr
-    range = xrange
+    range = xrange  # noqa: F821
 
     def indexbytes(buf, i):
         return ord(buf[i])
@@ -175,6 +175,8 @@ def make_Bpow():
     for i in range(253):
         Bpow.append(P)
         P = edwards_double(P)
+
+
 make_Bpow()
 
 

--- a/ed25519.py
+++ b/ed25519.py
@@ -74,7 +74,7 @@ def pow2(x, p):
 
 
 def inv(z):
-    """$= z^{-1} \mod q$, for z != 0"""
+    r"""$= z^{-1} \mod q$, for z != 0"""
     # Adapted from curve25519_athlon.c in djb's Curve25519.
     z2 = z * z % q                                # 2
     z9 = pow2(z2, 2) * z % q                      # 9

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py32,py33,pep8
+envlist = py27,pypy,py35,py37,py38,py39,pep8
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ commands = py.test -n 8
 deps =
     flake8
 commands =
-    flake8 .
+    # ignore E741 "ambiguous variable name"
+    flake8 --extend-ignore=E741 .
 
 [flake8]
 exclude = .tox/


### PR DESCRIPTION
Backstory:
* I'm trying to implement pep-458 in pip, but see annoying DeprecationWarnings about invalid escape sequences in docstrings in the test output
* one of the warnings come from securesystemslibs vendored copy of ed25519.py (https://github.com/secure-systems-lab/securesystemslib/issues/290)
* I'd rather make even tiny fixes at the actual upstream (here) so that the securesystemslib copy remains a 1-to-1 copy
* Obviously flake8 default rules and python versions have changed in the 7 years this has been untouched so I did the best I could with the travis and tox configs (I'm not an expert on those)
